### PR TITLE
Use amazonlinux:2 to build static bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 ARG DOCKER_ARCH
-FROM $DOCKER_ARCH/fedora:30 as builder
-RUN sed -i 's/^enabled=.*/enabled=0/' /etc/yum.repos.d/*modular*.repo
-RUN dnf group install -y "C Development Tools and Libraries"
-RUN dnf install -y glibc-static patch
+FROM $DOCKER_ARCH/amazonlinux:2 as builder
+RUN yum group install -y "Development Tools"
+RUN yum install -y glibc-static
 
 ARG bash_version=5.0
 ARG bash_patch_level=11


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

This modifies the static bash building section of the Dockerfile to use amazonlinux:2. This makes the version of static libraries compiled into bash the same as those libraries in AL2, which seems more sensible to me than having different versions of those libraries in the container.

It does also mean that the copyright information already present for bash's dependencies is available in /usr/share/licenses. (bash contains it's own copyright information in `bash --version`).

**Testing done:**

Ran `make`. Didn't test aarch64, but I expect it to work...

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
