### PR TITLE
Add license headers to our scripts

### DIFF
--- a/sheltie
+++ b/sheltie
@@ -1,4 +1,7 @@
 #!/bin/bash
+# This file is part of Bottlerocket.
+# Copyright Amazon.com, Inc., its affiliates, or other contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 if [[ $EUID -ne 0  ]]; then
     echo "sheltie must be run as root, you can use 'sudo sheltie' in the admin container"

--- a/start_admin_sshd.sh
+++ b/start_admin_sshd.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# This file is part of Bottlerocket.
+# Copyright Amazon.com, Inc., its affiliates, or other contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 set -e
 
 mkdir -p /home/ec2-user/.ssh/


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/469

**Description of changes:**

We normally don't add license headers to files in Bottlerocket, but `sheltie` and `start_admin_sshd.sh` are the only files in the admin container written by us (in this case, the Bottlerocket developers) that warrant license information. In this case, we believe a copyright header is the right thing instead of adding COPYRIGHT and LICENSE-*.

**Testing done:**

`make` works.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
