### PR TITLE
sheltie: use /proc to find the bash binary

### DIFF
--- a/sheltie
+++ b/sheltie
@@ -9,7 +9,12 @@ if [[ $EUID -ne 0  ]]; then
 fi
 
 # Location of the container's rootfs on the host filesystem
-ROOT_FS_PATH="/run/host-containerd/io.containerd.runtime.v1.linux/default/admin/rootfs"
+# Because we have a shared pid namespace, /proc inside the container matches
+# /proc outside the container.  The special directory 'root' inside a given
+# process directory in /proc contains that process's view of the filesystem.
+# We use ${PPID} to indicate the pid of the parent process of this script so we
+# can see the container's root filesystem inside this directory.
+ROOT_FS_PATH="/proc/${PPID}/root"
 BASH_PATH="/opt/bin/bash"
 
 # Start the root shell on the Bottlerocket host


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket-admin-container/issues/7

**Description of changes:**
Because we have a shared pid namespace, /proc inside the container matches /proc outside the container.  The special directory 'root' inside a given process directory in /proc contains that process's view of the filesystem.

We can thus locate the container's root filesystem by taking advantage of the interpreter's /proc directory.

In order to make this work, we rely on the parent process existing in the container's mount namespace, so that the path we construct maps properly to the container's filesystem.

**Testing done:**
Tested locally with `docker run -it --rm --privileged --pid=host`.  @etungsten tested it with Bottlerocket.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
