### PR TITLE
Use buildkit for docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ dist: all
 	docker save $(IMAGE_NAME) | gzip > $(DISTFILE)
 
 # Build the container image.
+build: export DOCKER_BUILDKIT = 1
 build:
 	docker build $(DOCKER_BUILD_FLAGS) \
 		--tag $(IMAGE_NAME) \


### PR DESCRIPTION
**Description of changes:**
Switch from old docker build environment to docker buildkit by default

**Testing done:**
Built the container a few times with and without buildkit. Builds were about 30s faster

Buildkit
real    2m12.879s
user    0m1.077s
sys     0m0.536s

without Buildkit
real    2m45.331s
user    0m0.400s
sys     0m0.294s