### PR TITLE
Add procps-ng to installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN test -n "$IMAGE_VERSION"
 LABEL "org.opencontainers.image.version"="$IMAGE_VERSION"
 
 RUN yum update -y \
-    && yum install -y openssh-server sudo util-linux \
+    && yum install -y openssh-server sudo util-linux procps-ng \
     && yum clean all
 
 COPY --from=builder /opt/bash /opt/bin/


### PR DESCRIPTION
**Description of changes:**

I often use the admin container to find out what's going on with my Bottlerocket host, and that often involves looking at the processes that are running.  This adds procps-ng, so we have classics like `ps` and `top`.

Adds 292k to installed size.

**Testing done:**

Built and ran the container, `ps` and `top` worked.  `make check` passes.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
