### PR TITLE
Add authorized_keys to TrustedUserCAKeys for certificate-based authen…

### DIFF
--- a/sshd_config
+++ b/sshd_config
@@ -3,7 +3,7 @@ HostKey /.bottlerocket/host-containers/admin/etc/ssh/ssh_host_ecdsa_key
 HostKey /.bottlerocket/host-containers/admin/etc/ssh/ssh_host_ed25519_key
 
 PasswordAuthentication no
-
+TrustedUserCAKeys /home/ec2-user/.ssh/authorized_keys
 ChallengeResponseAuthentication no
 
 UsePAM yes

--- a/sshd_config
+++ b/sshd_config
@@ -3,8 +3,11 @@ HostKey /.bottlerocket/host-containers/admin/etc/ssh/ssh_host_ecdsa_key
 HostKey /.bottlerocket/host-containers/admin/etc/ssh/ssh_host_ed25519_key
 
 PasswordAuthentication no
-TrustedUserCAKeys /home/ec2-user/.ssh/authorized_keys
 ChallengeResponseAuthentication no
+
+# Allow authentication with standard key pairs or certificates.
+AuthorizedKeysFile .ssh/authorized_keys
+TrustedUserCAKeys /home/ec2-user/.ssh/authorized_keys
 
 UsePAM yes
 


### PR DESCRIPTION
…tication

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#17 


**Description of changes:**
Allows the authorized_keys file to also be used for certificate-based authentication. For larger organizations, certificate based authentication is desirable because it allows for short-lived credentials and allows for the CA to be the decider of who has access to which machines. 

**Testing done:**
- Tested ssh access on EC2 with both a public/private pair (existing use case) as well as with a different public/private pair signed by a CA (with the CA's public key being the one in authorized_keys)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
