### PR TITLE
Improve error handling and logging during ssh setup

### DIFF
--- a/start_admin_sshd.sh
+++ b/start_admin_sshd.sh
@@ -21,8 +21,10 @@ get_user_data_keys() {
     # Extract the keys from user-data json
     local raw_keys
     local key_type="${1:?}"
-    if ! raw_keys=$(jq --arg key_type "${key_type}" -e -r '.["ssh"][$key_type][]' "${user_data}" 2>/dev/null); then
-      log "Failed to parse ${key_type} from ${user_data}"
+    # ? signifies an optional object identifier-index and doesn't return a 'failed to iterate' error
+    # in the event that a key_type is missing. If jq returns nothing, then that is caught by the -z.
+    if ! raw_keys=$(jq --arg key_type "${key_type}" -e -r '.["ssh"][$key_type][]?' "${user_data}") \
+    || [[ -z "${raw_keys}" ]]; then
       return 1
     fi
 
@@ -66,7 +68,8 @@ chown "${local_user}" -R "${user_ssh_dir}"
 
 # If there were no successful auth methods, then users cannot authenticate
 if [[ "${available_auth_methods}" -eq 0 ]]; then
-  log "Failed to configure ssh authentication"
+  user_data_condensed=$(tr -d '[:space:]' < "${user_data}")
+  log "Failed to configure ssh authentication with user-data: ${user_data_condensed}"
   exit 1
 fi
 

--- a/start_admin_sshd.sh
+++ b/start_admin_sshd.sh
@@ -67,6 +67,7 @@ chown "${local_user}" -R "${user_ssh_dir}"
 # If there were no successful auth methods, then users cannot authenticate
 if [[ "${available_auth_methods}" -eq 0 ]]; then
   log "Failed to configure ssh authentication"
+  exit 1
 fi
 
 # Generate the server keys
@@ -87,6 +88,7 @@ for key in rsa ecdsa ed25519; do
     chmod 644 "${ssh_host_key_dir}/ssh_host_${key}_key.pub"
   else
     log "Failure to generate host ${key} ssh keys"
+    exit 1
   fi
 done
 


### PR DESCRIPTION
**Issue number:**

N/A


**Description of changes:**

This adds exits on failure to two configuration checkpoints in the `start_admin_sshd.sh` script in order to prevent an improperly configured ssh daemon from starting. Prior to this, an error would be printed, but the script would continue to run.

This also replaces a forward of `stderr` to `/dev/null` when getting `user-data` keys and replaces the in-function error message with a more contextual message when there are no available auth methods. The available auth methods check error will output the `user-data` JSON to help with troubleshooting.

These changes will, among other things, prevent this common error message printed to the EC2 console when a user relies on `authorized_keys` as opposed to `trusted_user_ca_keys`:
```
host-ctr[905]: Failed to parse trusted_user_ca_keys from /.bottlerocket/host-containers/admin/user-data
```


**Testing done:**

- Launched publicly available `aws-ecs-1` ami.
- Instance connected to ecs cluster.
- Test task deployed successfully.
- Connected to control container via ssm session.
- Changed the source for the admin container and enabled it.
- Connected to admin container via ssh.
- Ran `sudo sheltie` to verify root shell was still available.
- Checked for failed systemd units.

After that, I went through several test cases of disabling the admin container, posting a new base64-encoded block to `host-containers.admin.user-data`,  re-enabling the admin container, and checking the connection.
- :white_check_mark: Empty JSON Structure (expected fail)
- :white_check_mark: Custom authorized key
- :white_check_mark: Several keys, some good, some bad (only the strings that could be parsed by ssh-keygen were present in `authorized_keys`)
- :white_check_mark: Authorized key AND trusted user CA key (`.ssh/authorized_keys`, `/etc/ssh/trusted_user_ca_keys.pub`, and `/etc/ssh/sshd_config` looked as expected)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
