### PR TITLE
Switch paths from `host-containers/admin` to `host-containers/current`

### DIFF
--- a/sshd_config
+++ b/sshd_config
@@ -1,6 +1,6 @@
-HostKey /.bottlerocket/host-containers/admin/etc/ssh/ssh_host_rsa_key
-HostKey /.bottlerocket/host-containers/admin/etc/ssh/ssh_host_ecdsa_key
-HostKey /.bottlerocket/host-containers/admin/etc/ssh/ssh_host_ed25519_key
+HostKey /.bottlerocket/host-containers/current/etc/ssh/ssh_host_rsa_key
+HostKey /.bottlerocket/host-containers/current/etc/ssh/ssh_host_ecdsa_key
+HostKey /.bottlerocket/host-containers/current/etc/ssh/ssh_host_ed25519_key
 
 PasswordAuthentication no
 

--- a/start_admin_sshd.sh
+++ b/start_admin_sshd.sh
@@ -9,8 +9,9 @@ log() {
 }
 
 declare -r local_user="ec2-user"
-declare -r ssh_host_key_dir="/.bottlerocket/host-containers/admin/etc/ssh"
-declare -r user_data="/.bottlerocket/host-containers/admin/user-data"
+declare -r persistent_storage_base_dir="/.bottlerocket/host-containers/current"
+declare -r ssh_host_key_dir="${persistent_storage_base_dir}/etc/ssh"
+declare -r user_data="${persistent_storage_base_dir}/user-data"
 declare -r user_ssh_dir="/home/${local_user}/.ssh"
 available_auth_methods=0
 


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This replaces any code that referenced `host-containers/admin` with the recently introduced `current` dir to support admin containers with a custom name.

**Testing done:**

- Launched `aws-ecs-1` ami with the `admin` container disabled and a `custom-admin` container enabled.
- Instance connected to ecs cluster.
- Test task deployed successfully.
- Connected to `custom-admin` container via ssh.
- Verified that `/.bottlerocket/host-containers` contained two directories: `custom-admin` and `current`
- `cat etc/ssh/sshd_config` to verify the host keys mapped to `/.bottlerocket/host-containers/current/etc/ssh/`.
- Verified that `/.bottlerocket/host-containers/current/etc/ssh/` contained host keys.
- Ran `sudo sheltie` to verify root shell was still available.
- Checked for failed systemd units.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
