### PR TITLE
Fix condensed user data

### DIFF
--- a/start_admin_sshd.sh
+++ b/start_admin_sshd.sh
@@ -86,7 +86,7 @@ chown -R "${LOCAL_USER}:" "${USER_SSH_DIR}"
 
 # If there were no successful auth methods, then users cannot authenticate
 if [[ "${available_auth_methods}" -eq 0 ]]; then
-  user_data_condensed=$(tr -d '[:space:]' < "${USER_DATA}")
+  user_data_condensed=$(jq -e -c . "${USER_DATA}" 2>/dev/null || cat "${USER_DATA}")
   log "Failed to configure ssh authentication with user-data: ${user_data_condensed}"
   exit 1
 fi


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This replaces the `tr -d '[:space:]'` which removed all whitespace, including intentional whitespace.
`jq -c` compacts output to delete extraneous spaces without removing intentional ones.
If the user data is not JSON, then we will simply `cat` out the file.


**Testing done:**

Without specified user-data:
- Launched `aws-ecs-1` instance.
- Instance connected to ecs cluster.
- Test task deployed successfully.
- Connected to admin container via ssh.
- Ran `sudo sheltie` to verify root shell was still available.
- Checked for failed systemd units.

With purposefully malformed user data
- Launched instance with `user-data` set to base64-encoded "Hello world"
- Verified in the EC2 console that the expected errors appeared and printed "Hello world"
- Launched instance with mostly correct `user-data` but `authorized_keyz` instead of `authorized_keys`
- Verified in the EC2 console that the error showed the JSON without extraneous spaces, but preserving the one between the key and the host that generated it. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
