### PR TITLE
Revert "Add exits to sshd configuration script"

### DIFF
--- a/start_admin_sshd.sh
+++ b/start_admin_sshd.sh
@@ -90,7 +90,6 @@ chown -R "${LOCAL_USER}:" "${USER_SSH_DIR}"
 if [[ "${available_auth_methods}" -eq 0 ]]; then
   user_data_condensed=$(jq -e -c . "${USER_DATA}" 2>/dev/null || cat "${USER_DATA}")
   log "Failed to configure ssh authentication with user-data: ${user_data_condensed}"
-  exit 1
 fi
 
 # Generate the server keys
@@ -111,7 +110,6 @@ for key_alg in rsa ecdsa ed25519; do
     chmod 644 "${SSH_HOST_KEY_DIR}/ssh_host_${key_alg}_key.pub"
   else
     log "Failure to generate host ${key_alg} ssh keys"
-    exit 1
   fi
 done
 


### PR DESCRIPTION
**Issue number:**

https://github.com/bottlerocket-os/bottlerocket-admin-container/issues/32

**Description of changes:**

This reverts commit ee2a589049581c8df68c59e006ce2f05772ec8aa.

By allowing the ssh daemon to start without authentication keys, users will get a clear "Permission denied" error if they haven't add them.

**Testing done:**

- Launched `aws-ecs-1` instance with non-ssh user-data.
- Instance connected to ecs cluster.
- Test task deployed successfully.
- Tried to connect to admin container: `ec2-user@###########: Permission denied (publickey).`
- Updated user-data with public keys via the control container.
- Connected to admin container via ssh.
- Ran `sudo sheltie` to verify root shell was still available.
- Checked for failed systemd units.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
