### PR TITLE
Add helper to run processes in other host containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,11 +59,10 @@ ADD --chown=root:root motd /etc/
 ADD --chown=root:root ec2-user.sudoers /etc/sudoers.d/ec2-user
 ADD start_admin_sshd.sh /usr/sbin/
 ADD ./sshd_config /etc/ssh/
-ADD ./sheltie /usr/bin/
+ADD ./sheltie ./collie /usr/bin/
 
 RUN chmod 440 /etc/sudoers.d/ec2-user
-RUN chmod +x /usr/sbin/start_admin_sshd.sh
-RUN chmod +x /usr/bin/sheltie
+RUN chmod +x /usr/sbin/start_admin_sshd.sh /usr/bin/sheltie /usr/bin/collie
 RUN groupadd -g 274 api
 RUN useradd -m -G users,api ec2-user
 

--- a/collie
+++ b/collie
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+   cat <<-EOF >&2
+	Usage: collie [ --tty | -t ] CONTAINER [ COMMAND [ ARGS ] ]
+
+	Runs the given command inside the given host container.
+
+	COMMAND defaults to /bin/bash.
+	EOF
+}
+
+TTY=""
+CONTAINER=""
+
+while [ "${#}" -gt 0 ]; do
+   case "${1}" in
+      --tty | -t ) TTY="please" ;;
+      --help | -h ) usage; exit 0 ;;
+      -*) usage; exit 1 ;;
+      *)
+         if [ -z "${CONTAINER}" ]; then
+            CONTAINER="${1}"
+         else
+            # remainder is command/args
+            break
+         fi
+         ;;
+   esac
+   shift
+done
+
+if [ -z "${CONTAINER}" ]; then
+   echo -e "Must specify host container name.\n" >&2
+   usage
+   exit 1
+fi
+
+if [ "${#}" -eq 0 ]; then
+   TTY="yes, so the /bin/bash default works as expected"
+fi
+
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "collie must be run as root, try 'sudo collie'" >&2
+    exit 1
+fi
+
+exec nsenter -t 1 -a \
+   /bin/ctr -a /run/host-containerd/containerd.sock \
+   task exec \
+   --exec-id "collie-$$-${RANDOM}" \
+   ${TTY:+--tty} \
+   "${CONTAINER}" \
+   "${@:-/bin/bash}"

--- a/motd
+++ b/motd
@@ -9,3 +9,8 @@ To permit more intrusive troubleshooting, including actions that mutate the
 running state of the Bottlerocket host, we provide a tool called "sheltie"
 (`sudo sheltie`).  When run, this tool drops you into a root shell in the
 Bottlerocket host's root filesystem.
+
+We also provide a tool called "collie" that can run processes in other host
+containers for debugging purposes.  It runs `/bin/bash` by default, so for
+example, running `sudo collie control` will give you a shell in the control
+container.


### PR DESCRIPTION
**Issue number:**

This is a partial solution to https://github.com/bottlerocket-os/bottlerocket/issues/367 that allows you to access other host containers from the admin container.  (A full solution would allow access from any host container with API access, which has some design challenges, but this simple helper eases some currently ugly use cases around debugging host containers.)

**Description of changes:**

Adds a `collie` helper, similar to `sheltie`, that `coll`s programs in other host containers using nsenter and `ctr exec`.

**Testing done:**

The default case gives you bash, with a TTY:
```
$ sudo collie admin
bash-4.2#
```

You can run other processes; I imagine a common use will be looking at files, and you can redirect them to a file to copy them out.
```
$ sudo collie control head -n1 /etc/motd
Welcome to Bottlerocket's control container!
```

(A number of other commands work as expected, too.)

Error from a nonexistent container:
```
$ sudo collie alsdkjf
ctr: container "alsdkjf" in namespace "default": not found
```

Usage message without arguments:
```
$ sudo collie
Must specify host container name.

Usage: collie [ --tty | -t ] CONTAINER [ COMMAND [ ARGS ] ]

Runs the given command inside the given host container.

COMMAND defaults to /bin/bash.
```

Usage message without sudo:
```
$ collie control
collie must be run as root, try 'sudo collie'
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
