### PR TITLE
Enable EC2 Instance Connect for ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "aws-ec2-instance-connect-config"]
+	path = aws-ec2-instance-connect-config
+	url = https://github.com/aws/aws-ec2-instance-connect-config

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ dist: all
 # Build the container image.
 build: export DOCKER_BUILDKIT = 1
 build:
+	git submodule update --init
 	docker build $(DOCKER_BUILD_FLAGS) \
 		--tag $(IMAGE_NAME) \
 		--build-arg IMAGE_VERSION="$(IMAGE_VERSION)" \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Then run `make`!
 
 ## Authenticating with the Admin Container
 
+### Uploading user keys
 Starting from v0.6.0, users have the option to pass in their own ssh keys rather than the admin container relying on the AWS instance metadata service (IMDS).
 
 Users can add their own keys by populating the admin container's user-data with a base64-encoded JSON block.
@@ -41,3 +42,8 @@ Once you've created your JSON, you'll need to base64-encode it and set it as the
 # ex: echo '{"ssh":{"authorized-keys":[]}}' | base64
 user-data = "eyJzc2giOnsiYXV0aG9yaXplZC1rZXlzIjpbXX19Cg=="
 ```
+
+### EC2 instance connect
+
+If your bottlerocket instance profile is [configured to allow EC2 Instance Connect](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-set-up.html#ec2-instance-connect-configure-IAM-role),
+you can connect to the admin container (from 0.7.2).

--- a/sshd_config
+++ b/sshd_config
@@ -17,3 +17,7 @@ Subsystem sftp	/usr/libexec/openssh/sftp-server
 
 # Configured by user data
 TrustedUserCAKeys /etc/ssh/trusted_user_ca_keys.pub
+
+# Enable EC2 Instance Connect
+AuthorizedKeysCommand /opt/aws/bin/eic_run_authorized_keys %u %f
+AuthorizedKeysCommandUser ec2-instance-connect


### PR DESCRIPTION
**Issue number:**

#38

**Description of changes:**

Enables EC2 Instance Connect for the admin container

**Testing done:**

Built an admin container, configured the bottle rocket instance to use the admin container, and used ssh via EC2 Instance Connect

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
