### PR TITLE
Support custom username

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,16 +57,13 @@ COPY --from=builder /opt/bash /opt/bin/
 RUN rm -f /etc/motd /etc/issue
 ADD --chown=root:root motd /etc/
 
-ADD --chown=root:root ec2-user.sudoers /etc/sudoers.d/ec2-user
 ADD start_admin_sshd.sh /usr/sbin/
 ADD ./sshd_config /etc/ssh/
 ADD ./sheltie /usr/bin/
 
-RUN chmod 440 /etc/sudoers.d/ec2-user
 RUN chmod +x /usr/sbin/start_admin_sshd.sh
 RUN chmod +x /usr/bin/sheltie
 RUN groupadd -g 274 api
-RUN useradd -m -G users,api ec2-user
 
 CMD ["/usr/sbin/start_admin_sshd.sh"]
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ To change allowed SSH ciphers to a specific set, you can add a ciphers section:
 }
 ```
 
+By default, the admin container's local user will be `ec2-user`. If you would like to change this, you can set the user value like so:
+
+```
+{
+  "user": "bottlerocket",
+  "ssh": {
+    "authorized-keys...",
+  }
+}
+```
+
 Once you've created your JSON, you'll need to base64-encode it and set it as the value of the admin host container's user-data setting in your [instance user data toml](https://github.com/bottlerocket-os/bottlerocket#using-user-data).
 
 ```

--- a/README.md
+++ b/README.md
@@ -23,24 +23,24 @@ To use custom public keys for `.ssh/authorized_keys` and/or custom CA keys for `
 
 ```
 {
-   "ssh":{
-      "authorized-keys":[
-         "ssh-rsa EXAMPLEAUTHORIZEDPUBLICKEYHERE my-key-pair"
-      ],
-      "trusted-user-ca-keys":[
-         "ssh-rsa EXAMPLETRUSTEDCAPUBLICKEYHERE authority@ssh-ca.example.com"
-      ]
-   }
+  "ssh": {
+    "authorized-keys": [
+      "ssh-rsa EXAMPLEAUTHORIZEDPUBLICKEYHERE my-key-pair"
+    ],
+    "trusted-user-ca-keys": [
+      "ssh-rsa EXAMPLETRUSTEDCAPUBLICKEYHERE authority@ssh-ca.example.com"
+    ]
+  }
 }
 ```
 
 If you want to access to the admin container using [EC2 instance connect](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Connect-using-EC2-Instance-Connect.html), set `authorized-keys-command` and `authorized-keys-command-user` as follows:
 ```
 {
-    "ssh": {
-      "authorized-keys-command": "/opt/aws/bin/eic_run_authorized_keys %u %f",
-      "authorized-keys-command-user": "ec2-instance-connect"
-    }
+  "ssh": {
+    "authorized-keys-command": "/opt/aws/bin/eic_run_authorized_keys %u %f",
+    "authorized-keys-command-user": "ec2-instance-connect"
+  }
 }
 ```
 
@@ -48,7 +48,7 @@ To change allowed SSH ciphers to a specific set, you can add a ciphers section:
 
 ```
 {
-  "ssh":{
+  "ssh": {
     "authorized-keys...",
     "ciphers": [
         "chacha20-poly1305@openssh.com",

--- a/ec2-user.sudoers
+++ b/ec2-user.sudoers
@@ -1,1 +1,0 @@
-ec2-user ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
**Issue number:**

https://github.com/bottlerocket-os/bottlerocket-admin-container/issues/31

**Description of changes:**

By default, the admin container's local user is `ec2-user`.
The first commit allows for the local user to be named something else.

The second commit cleans up the `README.md` by normalizing spacing of the examples.

**Testing done:**

- [x] No custom user-data.
- [x] User-data with custom user: `"user-data": "bottlerocket"`
- [x] User-data with malformed data: `"user-data": {]`
- [x] User-data with an empty string: `"user-data": ""`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
