### PR TITLE
Allow setting key exchange algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ To change allowed SSH ciphers to a specific set, you can add a ciphers section:
 }
 ```
 
+To change allowed key exchange algorithms to a specific set, you can add a
+`key-exchange-algorithms` section:
+```
+{
+  "ssh": {
+    "authorized-keys...",
+    "key-exchange-algorithms": [
+        "curve25519-sha256",
+        "curve25519-sha256@libssh.org",
+        "ecdh-sha2-nistp256",
+        "ecdh-sha2-nistp384",
+        "ecdh-sha2-nistp521",
+        "diffie-hellman-group-exchange-sha256"
+    ]
+  }
+}
+```
+
 By default, the admin container's local user will be `ec2-user`. If you would like to change this, you can set the user value like so:
 
 ```

--- a/start_admin_sshd.sh
+++ b/start_admin_sshd.sh
@@ -112,6 +112,11 @@ if ciphers=$(jq -r -e -c '.["ssh"]["ciphers"]? | join(",")' "${USER_DATA}" 2>/de
   echo "Ciphers ${ciphers}" >> "${SSHD_CONFIG_FILE}"
 fi
 
+# Populate KexAlgorithms with all the key exchange algorithms found in user-data
+if kex_algorithms=$(jq -r -e -c '.["ssh"]["key-exchange-algorithms"]? | join(",")' "${USER_DATA}" 2>/dev/null); then
+  echo "KexAlgorithms ${kex_algorithms}" >> "${SSHD_CONFIG_FILE}"
+fi
+
 # Check the configurations are for EC2 instance connect
 declare -i use_eic=0
 if [[ $authorized_keys_command == /opt/aws/bin/eic_run_authorized_keys* ]] \


### PR DESCRIPTION
**Description of changes:**

As an example, to disable diffie-hellman-group1-sha1 and
diffie-hellman-group-exchange-sha1 as per

https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16

this change allows the customization of key exchange algorithms to
remove unsatisfactory algorithms (README.md has an example that meets
the requirements)


**Testing done:**

Tested creating a bottlerocket host using an inhouse-built admin container - can confirm that KexAlgorithms is correctly set now.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
