### PR TITLE
sheltie: add ability to run single commands

### DIFF
--- a/sheltie
+++ b/sheltie
@@ -18,4 +18,8 @@ ROOT_FS_PATH="/proc/${PPID}/root"
 BASH_PATH="/opt/bin/bash"
 
 # Start the root shell on the Bottlerocket host
-exec nsenter -t 1 -a "${ROOT_FS_PATH}${BASH_PATH}"
+if [[ ${#@} -ne 0 ]]; then
+  exec nsenter -t 1 -a -- "$@"
+else
+  exec nsenter -t 1 -a "${ROOT_FS_PATH}${BASH_PATH}"
+fi


### PR DESCRIPTION
**Description of changes:**

Rather than entering a full `bash` shell, you can pass a command as an argument.

Example: `sudo sheltie cat /etc/os-release`.

**Testing done:**

- Running `sudo sheltie` put me in an interactive `bash` shell.
- Running `sudo sheltie cat /etc/os-release` simply printed my Bottlerocket release info.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
