### PR TITLE
Run yum update during Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG DOCKER_ARCH
 FROM $DOCKER_ARCH/amazonlinux:2 as builder
+RUN yum update -y
 RUN yum group install -y "Development Tools"
 RUN yum install -y glibc-static
 


### PR DESCRIPTION
Description of changes:
This performs a yum update of the underlying Amazon Linux container prior to building the control container.

Testing done:

Confirmed that the build successfully performs a yum update prior to building the rest of the image.
Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.