### PR TITLE
Various housekeeping changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2 as builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 as builder
 RUN yum group install -y "Development Tools"
 RUN yum install -y glibc-static
 
@@ -40,7 +40,7 @@ RUN CC=""/usr/local/musl/bin/musl-gcc CFLAGS="-Os -DHAVE_DLOPEN=0" \
 RUN make -j`nproc`
 RUN cp bash /opt/bash
 
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 ARG IMAGE_VERSION
 # Make the container image version a mandatory build argument

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG DOCKER_ARCH
-FROM $DOCKER_ARCH/amazonlinux:2 as builder
+FROM amazonlinux:2 as builder
 RUN yum group install -y "Development Tools"
 RUN yum install -y glibc-static
 
@@ -41,7 +40,7 @@ RUN CC=""/usr/local/musl/bin/musl-gcc CFLAGS="-Os -DHAVE_DLOPEN=0" \
 RUN make -j`nproc`
 RUN cp bash /opt/bash
 
-FROM $DOCKER_ARCH/amazonlinux:2
+FROM amazonlinux:2
 
 ARG IMAGE_VERSION
 # Make the container image version a mandatory build argument

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,11 @@ COPY --from=builder /opt/bash /opt/bin/
 RUN rm -f /etc/motd /etc/issue
 COPY --chown=root:root motd /etc/
 
+ARG CUSTOM_PS1='[\u@admin]\$ '
+RUN echo "PS1='$CUSTOM_PS1'" > "/etc/profile.d/bottlerocket-ps1.sh" \
+    && echo "PS1='$CUSTOM_PS1'" >> "/root/.bashrc" \
+    && echo "cat /etc/motd" >> "/root/.bashrc"
+
 COPY --chmod=755 start_admin_sshd.sh /usr/sbin/
 COPY ./sshd_config /etc/ssh/
 COPY --chmod=755 ./sheltie /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,11 +54,11 @@ RUN yum update -y \
 COPY --from=builder /opt/bash /opt/bin/
 
 RUN rm -f /etc/motd /etc/issue
-ADD --chown=root:root motd /etc/
+COPY --chown=root:root motd /etc/
 
-ADD --chmod=755 start_admin_sshd.sh /usr/sbin/
-ADD ./sshd_config /etc/ssh/
-ADD --chmod=755 ./sheltie /usr/bin/
+COPY --chmod=755 start_admin_sshd.sh /usr/sbin/
+COPY ./sshd_config /etc/ssh/
+COPY --chmod=755 ./sheltie /usr/bin/
 
 RUN groupadd -g 274 api
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,12 +56,10 @@ COPY --from=builder /opt/bash /opt/bin/
 RUN rm -f /etc/motd /etc/issue
 ADD --chown=root:root motd /etc/
 
-ADD start_admin_sshd.sh /usr/sbin/
+ADD --chmod=755 start_admin_sshd.sh /usr/sbin/
 ADD ./sshd_config /etc/ssh/
-ADD ./sheltie /usr/bin/
+ADD --chmod=755 ./sheltie /usr/bin/
 
-RUN chmod +x /usr/sbin/start_admin_sshd.sh
-RUN chmod +x /usr/bin/sheltie
 RUN groupadd -g 274 api
 
 CMD ["/usr/sbin/start_admin_sshd.sh"]

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,8 @@ dist: all
 	docker save $(IMAGE_NAME) | gzip > $(DISTFILE)
 
 # Build the container image.
-build: export DOCKER_BUILDKIT = 1
 build:
-	docker build $(DOCKER_BUILD_FLAGS) \
+	DOCKER_BUILDKIT=1 docker build $(DOCKER_BUILD_FLAGS) \
 		--tag $(IMAGE_NAME) \
 		--build-arg IMAGE_VERSION="$(IMAGE_VERSION)" \
 		-f Dockerfile . >&2

--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,8 @@ DESTDIR ?= .
 # tarball.
 DISTFILE ?= $(subst /,,$(DESTDIR))/$(subst /,_,$(IMAGE_NAME)).tar.gz
 
-# These values derive ARCH and DOCKER_ARCH which are needed by dependencies in
-# image build defaulting to system's architecture when not specified.
-#
-# UNAME_ARCH is the runtime architecture of the building host.
 UNAME_ARCH = $(shell uname -m)
-# ARCH is the target architecture which is being built for.
 ARCH ?= $(lastword $(subst :, ,$(filter $(UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
-# DOCKER_ARCH is the docker specific architecture specifier used for building on
-# multiarch container images.
-DOCKER_ARCH ?= $(lastword $(subst :, ,$(filter $(ARCH):%,amd64:amd64 arm64:arm64v8)))
 
 .PHONY: all build check check-static-bash
 
@@ -40,8 +32,6 @@ build:
 	docker build $(DOCKER_BUILD_FLAGS) \
 		--tag $(IMAGE_NAME) \
 		--build-arg IMAGE_VERSION="$(IMAGE_VERSION)" \
-		--build-arg ARCH="$(ARCH)" \
-		--build-arg DOCKER_ARCH="$(DOCKER_ARCH)" \
 		-f Dockerfile . >&2
 
 # Run checks against the container image.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For more information about how the admin container fits into the Bottlerocket op
 
 ## Building the Container Image
 
-You'll need Docker 17.06.2 or later, for multi-stage build support.
+You'll need Docker 20.10 or later for multi-stage build, BuildKit, and chmod on COPY/ADD support.
 Then run `make`!
 
 ## Authenticating with the Admin Container


### PR DESCRIPTION
**Issue number:**

#44
#47

**Description of changes:**

This PR contains a couple small changes:
- Fix multi-arch builds by removing **ARCH**/**DOCKER_ARCH** build arguments.
(thus making the container compatible with `buildx --platform linux/<arch>`)
- Pull base images from Amazon ECR Public.
- Replace `RUN chmod +x` with **ADD**/**COPY** `--chmod 755`.
- Replace unnecessary **ADD**s with **COPY**s.
- Set a custom PS1 to show that you are in the admin container.

**Testing done:**

- Launched `aws-ecs-1` ami with new container set in userdata.
- Enabled the admin container via the control container's APIclient.
- Verified APIclient exec functionality.
- Verified Bottlerocket access via `sudo sheltie`.
- Connected to admin container via ec2 instance connect.

**Additional testing done:**

- [x] Build with `buildx` using `--platform linux/amd64`.
- [x] Build with `buildx` using `--platform linux/arm64`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
