### PR TITLE
Serial console access support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN test -n "$IMAGE_VERSION"
 LABEL "org.opencontainers.image.version"="$IMAGE_VERSION"
 
 RUN yum update -y \
-    && yum install -y openssh-server sudo util-linux procps-ng jq openssl ec2-instance-connect \
+    && yum install -y openssh-server sudo shadow-utils util-linux procps-ng jq openssl ec2-instance-connect \
     && yum clean all
 
 COPY --from=builder /opt/bash /opt/bin/
@@ -55,16 +55,18 @@ COPY --from=builder /usr/share/licenses/bash /usr/share/licenses/bash
 RUN rm -f /etc/motd /etc/issue
 COPY --chown=root:root motd /etc/
 
+COPY --chown=root:root units /etc/systemd/user/
+
 ARG CUSTOM_PS1='[\u@admin]\$ '
 RUN echo "PS1='$CUSTOM_PS1'" > "/etc/profile.d/bottlerocket-ps1.sh" \
     && echo "PS1='$CUSTOM_PS1'" >> "/root/.bashrc" \
     && echo "cat /etc/motd" >> "/root/.bashrc"
 
-COPY --chmod=755 start_admin_sshd.sh /usr/sbin/
+COPY --chmod=755 start_admin.sh /usr/sbin/
 COPY ./sshd_config /etc/ssh/
 COPY --chmod=755 ./sheltie /usr/bin/
 
 RUN groupadd -g 274 api
 
-CMD ["/usr/sbin/start_admin_sshd.sh"]
+CMD ["/usr/sbin/start_admin.sh"]
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This is the default admin container for [Bottlerocket](https://github.com/bottlerocket-os/bottlerocket).
 The admin container has an SSH server that lets you log in as ec2-user using your EC2-registered SSH key.
+It also runs agetty services for serial console devices to allow console access.
 It runs outside of Bottlerocket's container orchestrator in a separate instance of containerd.
 
 The admin container is disabled by default in Bottlerocket.
@@ -89,6 +90,23 @@ By default, the admin container's local user will be `ec2-user`. If you would li
     "authorized-keys...",
   }
 }
+```
+
+For logging in via serial console, you can specify a password for the primary user like so:
+
+```
+{
+  "user": "bottlerocket",
+  "password-hash": "$y$jFT$NER...",
+  "ssh": {
+    "authorized-keys...",
+  }
+}
+```
+
+Where the password-hash can be generated from:
+```bash
+mkpasswd -m yescrypt -R 11 <desired password>
 ```
 
 Once you've created your JSON, you'll need to base64-encode it and set it as the value of the admin host container's user-data setting in your [instance user data toml](https://github.com/bottlerocket-os/bottlerocket#using-user-data).

--- a/start_admin.sh
+++ b/start_admin.sh
@@ -10,6 +10,11 @@ declare -r PERSISTENT_STORAGE_BASE_DIR="/.bottlerocket/host-containers/current"
 declare -r SSH_HOST_KEY_DIR="${PERSISTENT_STORAGE_BASE_DIR}/etc/ssh"
 declare -r USER_DATA="${PERSISTENT_STORAGE_BASE_DIR}/user-data"
 
+if [ ! -s "${USER_DATA}" ]; then
+  log "Admin host-container user-data is empty, going to sleep forever"
+  exec sleep infinity
+fi
+
 # Fetch user from user-data json (if any). Default to 'ec2-user' if null or invalid.
 if ! LOCAL_USER=$(jq -e -r '.["user"] // "ec2-user"' "${USER_DATA}" 2>/dev/null) \
 || [[ ! "${LOCAL_USER}" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]]; then

--- a/start_admin.sh
+++ b/start_admin.sh
@@ -111,7 +111,11 @@ enable_systemd_services() {
 # Create local user
 echo "${LOCAL_USER} ALL=(ALL) NOPASSWD: ALL" > "/etc/sudoers.d/${LOCAL_USER}"
 chmod 440 "/etc/sudoers.d/${LOCAL_USER}"
-useradd -m -G users,api "${LOCAL_USER}"
+# Skip user creation if the user already exists
+if ! id -u "${LOCAL_USER}" &>/dev/null; then
+  useradd -m "${LOCAL_USER}"
+fi
+usermod -G users,api "${LOCAL_USER}"
 if [[ -z "${PASSWORD_HASH}" ]]; then
   usermod -L "${LOCAL_USER}"
 else

--- a/start_admin.sh
+++ b/start_admin.sh
@@ -17,13 +17,18 @@ if ! LOCAL_USER=$(jq -e -r '.["user"] // "ec2-user"' "${USER_DATA}" 2>/dev/null)
   LOCAL_USER="ec2-user"
 fi
 
+# Fetch password-hash for serial console access.
+if ! PASSWORD_HASH=$(jq -r '.["password-hash"] // ""' "${USER_DATA}" 2>/dev/null); then
+  PASSWORD_HASH=""
+fi
+
 declare -r USER_SSH_DIR="/home/${LOCAL_USER}/.ssh"
 declare -r SSHD_CONFIG_DIR="/etc/ssh"
 declare -r SSHD_CONFIG_FILE="${SSHD_CONFIG_DIR}/sshd_config"
 
 # This is a counter used to verify at least
 # one of the methods below is available.
-declare -i available_auth_methods=0
+declare -i available_ssh_methods=0
 
 get_user_data_keys() {
     # Extract the keys from user-data json
@@ -69,34 +74,73 @@ EOF
   chmod 644 "${proxy_profile}"
 }
 
+# Set up agetty services for serial console access and the sshd daemon service
+enable_systemd_services() {
+  # Grab `console=` parameters from the kernel command line.
+  CONSOLES=()
+  for opt in $(cat /proc/cmdline) ; do
+     optarg="$(expr "${opt}" : '[^=]*=\(.*\)' 2>/dev/null ||:)"
+     optarg="${optarg%\"}"
+     optarg="${optarg#\"}"
+     case "${opt}" in
+        console=*) CONSOLES+=("${optarg%,*}") ;;
+     esac
+  done
+
+  HOST_DEVTMPFS="/.bottlerocket/rootfs/dev"
+  for console in "${CONSOLES[@]}" ; do
+     # Skip devices that don't exist.
+     [ -c "${HOST_DEVTMPFS}/${console}" ] || continue
+
+     # Otherwise instantiate a service from the template unit. This is normally
+     # done by `systemd-getty-generator`, but that skips over ordinary devices
+     # when run inside a container.
+     case "${console}" in
+        ttyS*|ttyAMA*|ttyUSB*)
+           systemctl --user enable "serial-getty@${console}.service"
+           ;;
+        tty*)
+           systemctl --user enable "getty@${console}.service"
+           ;;
+     esac
+  done
+  # Enable the SSH daemon service unit so we can run it in the background
+  systemctl --user enable "sshd.service"
+}
+
 # Create local user
 echo "${LOCAL_USER} ALL=(ALL) NOPASSWD: ALL" > "/etc/sudoers.d/${LOCAL_USER}"
 chmod 440 "/etc/sudoers.d/${LOCAL_USER}"
 useradd -m -G users,api "${LOCAL_USER}"
+if [[ -z "${PASSWORD_HASH}" ]]; then
+  usermod -L "${LOCAL_USER}"
+else
+  usermod -p "${PASSWORD_HASH}" "${LOCAL_USER}"
+fi
 mkdir -p "${USER_SSH_DIR}"
 chmod 700 "${USER_SSH_DIR}"
 
-# Populate authorized_keys with all the authorized keys found in user-data
+# Populate SSH authorized_keys with all the authorized keys found in user-data
 if authorized_keys=$(get_user_data_keys "authorized-keys") \
 || authorized_keys=$(get_user_data_keys "authorized_keys"); then
   ssh_authorized_keys="${USER_SSH_DIR}/authorized_keys"
   touch "${ssh_authorized_keys}"
   chmod 600 "${ssh_authorized_keys}"
   echo "${authorized_keys}" > "${ssh_authorized_keys}"
-  ((++available_auth_methods))
+  ((++available_ssh_methods))
 fi
 
-# Populate trusted_user_ca_keys with all the trusted ca keys found in user-data
+# Populate SSH trusted_user_ca_keys with all the trusted ca keys found in user-data
 if trusted_user_ca_keys=$(get_user_data_keys "trusted-user-ca-keys") \
 || trusted_user_ca_keys=$(get_user_data_keys "trusted_user_ca_keys"); then
   ssh_trusted_user_ca_keys="/etc/ssh/trusted_user_ca_keys.pub"
   touch "${ssh_trusted_user_ca_keys}"
   chmod 600 "${ssh_trusted_user_ca_keys}"
   echo "${trusted_user_ca_keys}" > "${ssh_trusted_user_ca_keys}"
-  ((++available_auth_methods))
+  ((++available_ssh_methods))
 fi
 
-# Set additional configurations
+# Set additional SSH configurations
 declare authorized_keys_command
 if authorized_keys_command=$(jq -e -r '.["ssh"]["authorized-keys-command"]?' "${USER_DATA}"); then
   echo "AuthorizedKeysCommand ${authorized_keys_command}" >> "${SSHD_CONFIG_FILE}"
@@ -122,15 +166,14 @@ declare -i use_eic=0
 if [[ $authorized_keys_command == /opt/aws/bin/eic_run_authorized_keys* ]] \
 && [[ $authorized_keys_command_user == "ec2-instance-connect" ]]; then
   use_eic=1
-  ((++available_auth_methods))
+  ((++available_ssh_methods))
 fi
 
 chown -R "${LOCAL_USER}:" "${USER_SSH_DIR}"
 
-# If there were no successful auth methods, then users cannot authenticate
-if [[ "${available_auth_methods}" -eq 0 ]]; then
-  user_data_condensed=$(jq -e -c . "${USER_DATA}" 2>/dev/null || cat "${USER_DATA}")
-  log "Failed to configure ssh authentication with user-data: ${user_data_condensed}"
+# If there were no available SSH auth methods, then users cannot connect via the SSH daemon
+if [[ "${available_ssh_methods}" -eq 0 ]]; then
+  log "No SSH authentication methods available in admin container user-data"
 fi
 
 # Generate the server keys
@@ -166,5 +209,9 @@ fi
 
 install_proxy_profile
 
-# Start a single sshd process in the foreground
-exec /usr/sbin/sshd -e -D
+enable_systemd_services
+
+# Persuade systemd that it's OK to run as a user manager.
+export XDG_RUNTIME_DIR="/run/user/${UID}"
+mkdir -p /run/systemd/system "${XDG_RUNTIME_DIR}"
+exec /usr/lib/systemd/systemd --user --unit=admin.target

--- a/units/admin.target
+++ b/units/admin.target
@@ -1,0 +1,2 @@
+[Unit]
+Description=Admin host container

--- a/units/getty@.service
+++ b/units/getty@.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Getty on %I
+DefaultDependencies=no
+
+[Service]
+Environment=TERM=xterm-256color
+ExecStart=-/sbin/agetty -o '-- \\u' --noclear - ${TERM}
+Type=idle
+Restart=always
+RestartSec=0
+UtmpIdentifier=%I
+StandardInput=tty
+StandardOutput=tty
+TTYPath=/.bottlerocket/rootfs/dev/%I
+TTYReset=yes
+TTYVHangup=yes
+TTYVTDisallocate=yes
+KillMode=process
+IgnoreSIGPIPE=no
+SendSIGHUP=yes
+
+[Install]
+WantedBy=admin.target

--- a/units/serial-getty@.service
+++ b/units/serial-getty@.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Serial Getty on %I
+DefaultDependencies=no
+
+[Service]
+Environment=TERM=xterm-256color
+ExecStart=-/sbin/agetty -o '-- \\u' --keep-baud 115200,57600,38400,9600 - ${TERM}
+Type=idle
+Restart=always
+RestartSec=0
+UtmpIdentifier=%I
+StandardInput=tty
+StandardOutput=tty
+TTYPath=/.bottlerocket/rootfs/dev/%I
+TTYReset=yes
+TTYVHangup=yes
+KillMode=process
+IgnoreSIGPIPE=no
+SendSIGHUP=yes
+
+[Install]
+WantedBy=admin.target

--- a/units/sshd.service
+++ b/units/sshd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=OpenSSH server daemon
+
+[Service]
+Type=notify
+EnvironmentFile=/etc/sysconfig/sshd
+ExecStart=/usr/sbin/sshd -e -D $OPTIONS
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+Restart=on-failure
+RestartSec=42s
+
+[Install]
+WantedBy=admin.target


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**

```
    Serial console support

    This adds getty services for each serial console device on the host so
    users can get to the admin container via serial console connections.

    As part of this change, the sshd process is now managed by a
    user-managed instance of systemd running in the admin container.

    All the admin container user-managed services are "WantedBy" the
    admin.target.

    Users can specify a password hash for the console login in the admin
    host container's user-data.

```


**Testing done:**
With no admin user-data specified. I was able to connect to the admin container via a serial console connection to my EC2 instance.
`sudo sheltie` works,
`apiclient` works.
I can still SSH to the admin container.
```
$ ssh -i ~/pem/etung.pem i-01b9b773cfed7c6c9.port0@serial-console.ec2-instance-connect.us-west-2.aws
[   30.635206] host-ctr[1605]: Created symlink /root/.config/systemd/user/admin.target.wants/getty@tty0.service, pointing to /etc/systemd/user/getty@.service.
[   30.694509] host-ctr[1605]: Created symlink /root/.config/systemd/user/admin.target.wants/serial-getty@ttyS0.service, pointing to /etc/systemd/user/serial-getty@.service.
[   30.738476] host-ctr[1605]: Created symlink /root/.config/systemd/user/admin.target.wants/sshd.service, pointing to /etc/systemd/user/sshd.service.
[   30.776554] host-ctr[1605]: Startup finished in 66ms.

Last login: Wed Apr 27 23:59:41 on /.bottlerocket/rootfs/dev/tty0
          Welcome to Bottlerocket's admin container!
    ╱╲
   ╱┄┄╲   This container provides access to the Bottlerocket host
   │▗▖│   filesystems (see /.bottlerocket/rootfs) and contains common
  ╱│  │╲  tools for inspection and troubleshooting.  It is based on
  │╰╮╭╯│  Amazon Linux 2, and most things are in the same places you
    ╹╹    would find them on an AL2 host.

To permit more intrusive troubleshooting, including actions that mutate the
running state of the Bottlerocket host, we provide a tool called "sheltie"
(`sudo sheltie`).  When run, this tool drops you into a root shell in the
Bottlerocket host's root filesystem.
[ec2-user@admin]$ env
HOSTNAME=
TERM=xterm-256color
SHELL=/bin/bash
HISTSIZE=1000
NO_PROXY=localhost,127.0.0.1,....yl4.us-west-2.eks.amazonaws.com,.cluster.local
USER=ec2-user
LS_COLORS=....
MAIL=/var/spool/mail/ec2-user
PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin:/home/ec2-user/bin
PWD=/home/ec2-user
HISTCONTROL=ignoredups
SHLVL=1
HOME=/home/ec2-user
no_proxy=localhost,127.0.0.1,....yl4.us-west-2.eks.amazonaws.com,.cluster.local
LOGNAME=ec2-user
_=/usr/bin/env
[ec2-user@admin]$ sudo sheltie
bash-5.1# exit
[ec2-user@admin]$ apiclient get settings.host-containers.admin
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "...",
        "superpowered": true,
        "user-data": "...."
      }
    }
  }
}
```


I then set up a new bottlerocket host with admin container user-data containing a password-hash for the console login for my custom user:
Userdata:
```
{
  "user": "erikson",
  "password-hash": "$6$rounds=1000$NER...",
  "ssh": {
    "authorized-keys...",
  }
}
```

Then trying to login via serial console:
```
ip-192-168-2-248 login: erikson
Password:
Last failed login: Thu Apr 28 00:33:17 UTC 2022 on /.bottlerocket/rootfs/dev/ttyS0
There were 2 failed login attempts since the last successful login.
          Welcome to Bottlerocket's admin container!
    ╱╲
   ╱┄┄╲   This container provides access to the Bottlerocket host
   │▗▖│   filesystems (see /.bottlerocket/rootfs) and contains common
  ╱│  │╲  tools for inspection and troubleshooting.  It is based on
  │╰╮╭╯│  Amazon Linux 2, and most things are in the same places you
    ╹╹    would find them on an AL2 host.

To permit more intrusive troubleshooting, including actions that mutate the
running state of the Bottlerocket host, we provide a tool called "sheltie"
(`sudo sheltie`).  When run, this tool drops you into a root shell in the
Bottlerocket host's root filesystem.
[erikson@admin]$ 
```

- [x] test on bare metal server bottlerocket host

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
