### PR TITLE
Symlink logger with true

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,5 +68,9 @@ COPY --chmod=755 ./sheltie /usr/bin/
 
 RUN groupadd -g 274 api
 
+# Reduces issues related to logger and our implementation of systemd. This is
+# necessary for scripts logging to logger, such as in EC2 Instance Connect.
+RUN ln -sf /usr/bin/true /usr/bin/logger
+
 CMD ["/usr/sbin/start_admin.sh"]
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/start_admin.sh
+++ b/start_admin.sh
@@ -170,7 +170,7 @@ if kex_algorithms=$(jq -r -e -c '.["ssh"]["key-exchange-algorithms"]? | join(","
   echo "KexAlgorithms ${kex_algorithms}" >> "${SSHD_CONFIG_FILE}"
 fi
 
-# Check the configurations are for EC2 instance connect
+# Check the configurations are for EC2 Instance Connect
 declare -i use_eic=0
 if [[ $authorized_keys_command == /opt/aws/bin/eic_run_authorized_keys* ]] \
 && [[ $authorized_keys_command_user == "ec2-instance-connect" ]]; then


### PR DESCRIPTION
**Description of changes:**

This addresses a regression where logger no longer has an interface to log to with our minimal implementation of systemd. This was causing EC2 Instance Connect to fail to parse keys and make them available on the host.

**Testing done:**

- Launched `aws-ecs-1` ami with new container set in userdata.
- Enabled the admin container via the control container's APIclient.
- Verified APIclient exec functionality.
- Verified Bottlerocket access via `sudo sheltie`.
- Connected to admin container via ec2 instance connect.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
