### PR TITLE
dockerfile: Remove /etc/config/selinux from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ LABEL "org.opencontainers.image.version"="$IMAGE_VERSION"
 RUN yum update -y \
     && yum install -y openssh-server sudo shadow-utils util-linux procps-ng jq openssl ec2-instance-connect \
     && yum clean all
+# Delete SELinux config file to prevent relabeling with contexts provided by the container's image
+RUN rm -rf /etc/selinux/config
 
 COPY --from=builder /opt/bash /opt/bin/
 COPY --from=builder /usr/share/licenses/bash /usr/share/licenses/bash


### PR DESCRIPTION
**Issue number:**
Closes #68


**Description of changes:**
```
The latest version of ec2-instance-connect has a dependency on the
selinux-policy and selinux-policy-targeted, which have a post-install
script that creates the /etc/config/selinux file within the container's
root filesystem to enforce SELinux. The libselinux library checks if
this file exists (among other things) to determine whether files
should be relabeled or not which is a problem with binaries in the
container's filesystem that have SELinux integration, since they will
attempt to relabel files using contexts provided by the container's
SELinux policies.

The SELinux contexts provided by the container's filesystem are not
valid since they are not present in the policy shipped in Bottlerocket.
Thus, any attempt to relabel the filesystems using contexts outside
the Bottlerocket's SELinux policy will result in an error. Deleting the
SELinux configuration file solves the problem, since the check described
above will fail.
```


**Testing done:**
- I built the admin container and deployed to a Bottlerocket host. I confirmed the admin container is running as expected:

```
[ec2-user@admin]$ apiclient get settings.host-containers.admin.source
{
  "settings": {
    "host-containers": {
      "admin": {
        "source": "#####/bottlerocket-admin-container:v0.9.1-87c2d648-dev-v2"
      }
    }
  }
}

[ec2-user@admin]$ sudo yum install -y ec2-instance-connect
Loaded plugins: ovl, priorities
amzn2-core                                                                                                                                       | 3.7 kB  00:00:00
(1/3): amzn2-core/2/x86_64/group_gz                                                                                                              | 2.5 kB  00:00:00
(2/3): amzn2-core/2/x86_64/updateinfo                                                                                                            | 495 kB  00:00:00
(3/3): amzn2-core/2/x86_64/primary_db                                                                                                            |  65 MB  00:00:00
Package ec2-instance-connect-1.1-19.amzn2.noarch already installed and latest version
Nothing to do

[ec2-user@admin]$ sudo useradd -m test1
[ec2-user@admin]$ grep test1 /etc/passwd
test1:x:1001:1001::/home/test1:/bin/bash
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
