### PR TITLE
Remove check for EC2 Instance Connect hostkey harvesting

### DIFF
--- a/start_admin.sh
+++ b/start_admin.sh
@@ -208,14 +208,6 @@ for key_alg in rsa ecdsa ed25519; do
   fi
 done
 
-
-if [[ ${use_eic} == 1 ]] && [[ ! -f "${SSH_HOST_KEY_DIR}/harvest" ]]; then
-  if ! /opt/aws/bin/eic_harvest_hostkeys; then
-    log "Failure to harvest hostkeys for EIC"
-  fi
-  touch "${SSH_HOST_KEY_DIR}/harvest"
-fi
-
 install_proxy_profile
 
 enable_systemd_services


### PR DESCRIPTION
**Description of changes:**

`eic_harvest_hostkeys` was removed from the `ec2-instance-connect` package, which was causing a _"Failure to harvest hostkeys for EIC"_ warning to print to the console. This commit simply removes that check.

**Testing done:**

- Built the container and launched with the latest bottlerocket.
- Connected to the instance using `mssh`.
- Verified the error was no longer printing the console using `aws ec2 get-console-output`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
