### PR TITLE
Run on cgroup v2 host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,15 @@ RUN test -n "$IMAGE_VERSION"
 LABEL "org.opencontainers.image.version"="$IMAGE_VERSION"
 
 RUN yum update -y \
-    && yum install -y openssh-server sudo shadow-utils util-linux procps-ng jq openssl ec2-instance-connect \
+    && yum install -y
+        ec2-instance-connect \
+        jq \
+        openssh-server \
+        openssl \
+        procps-ng \
+        shadow-utils \
+        sudo \
+        util-linux \
     && yum clean all
 # Delete SELinux config file to prevent relabeling with contexts provided by the container's image
 RUN rm -rf /etc/selinux/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,8 @@ RUN last_patch=$(awk '/^Patch[0-9]+/ { line = NR } END { print line }' systemd.s
     { \
         echo ;\
         echo '# Bottlerocket Patches'; \
+        echo 'Patch9501: 9500-cgroup-util-extract-cgroup-hierarchy-base-path-into-.patch'; \
+        echo 'Patch9502: 9501-cgroup-util-accept-cgroup-hierarchy-base-as-option.patch'; \
         echo ; \
     } >>systemd.mod.spec; \
     tail -n+$((last_patch + 1)) systemd.spec >>systemd.mod.spec; \

--- a/systemd-patches/9500-cgroup-util-extract-cgroup-hierarchy-base-path-into-.patch
+++ b/systemd-patches/9500-cgroup-util-extract-cgroup-hierarchy-base-path-into-.patch
@@ -1,0 +1,75 @@
+From 1b69dcdee96284abc05072d962e99436d00042f2 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Wed, 23 Nov 2022 13:06:49 +0000
+Subject: [PATCH 9500/9501] cgroup-util: extract cgroup hierarchy base path
+ into variable
+
+Just extracting the /sys/fs/cgroup path as the cgroup hierarchy base into its
+own definition to ease further changes. No functional changes in this commit.
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ src/shared/cgroup-util.c | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/src/shared/cgroup-util.c b/src/shared/cgroup-util.c
+index f1bed8a..b055dd8 100644
+--- a/src/shared/cgroup-util.c
++++ b/src/shared/cgroup-util.c
+@@ -41,6 +41,8 @@
+ #include "special.h"
+ #include "mkdir.h"
+ 
++static char *cg_hierarchy_base = "/sys/fs/cgroup";
++
+ int cg_enumerate_processes(const char *controller, const char *path, FILE **_f) {
+         _cleanup_free_ char *fs = NULL;
+         FILE *f;
+@@ -453,13 +455,13 @@ static int join_path(const char *controller, const char *path, const char *suffi
+ 
+         if (!isempty(controller)) {
+                 if (!isempty(path) && !isempty(suffix))
+-                        t = strjoin("/sys/fs/cgroup/", controller, "/", path, "/", suffix, NULL);
++                        t = strjoin(cg_hierarchy_base, "/", controller, "/", path, "/", suffix, NULL);
+                 else if (!isempty(path))
+-                        t = strjoin("/sys/fs/cgroup/", controller, "/", path, NULL);
++                        t = strjoin(cg_hierarchy_base, "/", controller, "/", path, NULL);
+                 else if (!isempty(suffix))
+-                        t = strjoin("/sys/fs/cgroup/", controller, "/", suffix, NULL);
++                        t = strjoin(cg_hierarchy_base, "/", controller, "/", suffix, NULL);
+                 else
+-                        t = strappend("/sys/fs/cgroup/", controller);
++                        t = strjoin(cg_hierarchy_base, "/", controller, NULL);
+         } else {
+                 if (!isempty(path) && !isempty(suffix))
+                         t = strjoin(path, "/", suffix, NULL);
+@@ -488,7 +490,7 @@ int cg_get_path(const char *controller, const char *path, const char *suffix, ch
+         if (_unlikely_(!good)) {
+                 int r;
+ 
+-                r = path_is_mount_point("/sys/fs/cgroup", false);
++                r = path_is_mount_point(cg_hierarchy_base, false);
+                 if (r < 0)
+                         return r;
+                 if (r == 0)
+@@ -512,7 +514,7 @@ static int check_hierarchy(const char *p) {
+                 return 0;
+ 
+         /* Check if this controller actually really exists */
+-        cc = strjoina("/sys/fs/cgroup/", p);
++        cc = strjoina(cg_hierarchy_base, "/", p);
+         if (laccess(cc, F_OK) < 0)
+                 return -errno;
+ 
+@@ -1043,7 +1045,7 @@ int cg_mangle_path(const char *path, char **result) {
+         assert(result);
+ 
+         /* First, check if it already is a filesystem path */
+-        if (path_startswith(path, "/sys/fs/cgroup")) {
++        if (path_startswith(path, cg_hierarchy_base)) {
+ 
+                 t = strdup(path);
+                 if (!t)
+-- 
+2.36.1
+

--- a/systemd-patches/9501-cgroup-util-accept-cgroup-hierarchy-base-as-option.patch
+++ b/systemd-patches/9501-cgroup-util-accept-cgroup-hierarchy-base-as-option.patch
@@ -1,0 +1,120 @@
+From 48de958400d2acc96dc3268c287782b33d7ae883 Mon Sep 17 00:00:00 2001
+From: Markus Boehme <markubo@amazon.com>
+Date: Wed, 4 Jan 2023 15:33:10 +0000
+Subject: [PATCH 9501/9501] cgroup-util: accept cgroup hierarchy base as option
+
+On an ordinary system, the cgroup hierarchy is expected to be located at
+`/sys/fs/cgroup`. Introduce the `--cgroup-base` option to `systemd` to
+make it look for the cgroup hierarchy at another location.
+
+The cgroup base may only be moved once and, preferably only during
+initialization while parsing the command line arguments to avoid
+confusion.
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ src/core/main.c          | 14 +++++++++++++-
+ src/shared/cgroup-util.c | 26 ++++++++++++++++++++++++++
+ src/shared/cgroup-util.h |  2 ++
+ 3 files changed, 41 insertions(+), 1 deletion(-)
+
+diff --git a/src/core/main.c b/src/core/main.c
+index 2d70ed0..ce0314a 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -79,6 +79,8 @@
+ #include "kmod-setup.h"
+ #include "emergency-action.h"
+ 
++#include "cgroup-util.h"
++
+ static enum {
+         ACTION_RUN,
+         ACTION_HELP,
+@@ -680,7 +682,8 @@ static int parse_argv(int argc, char *argv[]) {
+                 ARG_DESERIALIZE,
+                 ARG_SWITCHED_ROOT,
+                 ARG_DEFAULT_STD_OUTPUT,
+-                ARG_DEFAULT_STD_ERROR
++                ARG_DEFAULT_STD_ERROR,
++                ARG_CGROUP_BASE,
+         };
+ 
+         static const struct option options[] = {
+@@ -704,6 +707,7 @@ static int parse_argv(int argc, char *argv[]) {
+                 { "switched-root",            no_argument,       NULL, ARG_SWITCHED_ROOT            },
+                 { "default-standard-output",  required_argument, NULL, ARG_DEFAULT_STD_OUTPUT,      },
+                 { "default-standard-error",   required_argument, NULL, ARG_DEFAULT_STD_ERROR,       },
++                { "cgroup-base",              required_argument, NULL, ARG_CGROUP_BASE,             },
+                 {}
+         };
+ 
+@@ -880,6 +884,14 @@ static int parse_argv(int argc, char *argv[]) {
+                         arg_switched_root = true;
+                         break;
+ 
++                case ARG_CGROUP_BASE:
++                        r = cg_set_hierarchy_base(optarg);
++                        if (r < 0) {
++                                log_error_errno(r, "Failed to use cgroup hierarchy base to %s: %m", optarg);
++                                return r;
++                        }
++                        break;
++
+                 case 'h':
+                         arg_action = ACTION_HELP;
+                         if (arg_no_pager < 0)
+diff --git a/src/shared/cgroup-util.c b/src/shared/cgroup-util.c
+index b055dd8..e9f8d24 100644
+--- a/src/shared/cgroup-util.c
++++ b/src/shared/cgroup-util.c
+@@ -40,6 +40,7 @@
+ #include "fileio.h"
+ #include "special.h"
+ #include "mkdir.h"
++#include "refcnt.h"
+ 
+ static char *cg_hierarchy_base = "/sys/fs/cgroup";
+ 
+@@ -1839,3 +1840,28 @@ int cg_blkio_weight_parse(const char *s, uint64_t *ret) {
+         *ret = u;
+         return 0;
+ }
++
++int cg_set_hierarchy_base(const char *path) {
++        static RefCount base_set = REFCNT_INIT;
++        char *b;
++        int r;
++
++        assert(path);
++
++        r = is_dir(path, true);
++        if (r <= 0)
++                return r ? r : -ENOTDIR;
++
++        b = strdup(path);
++        if (!b)
++                return -ENOMEM;
++
++        if (REFCNT_INC(base_set) > 2) {
++                free(b);
++                return -EINVAL;
++        }
++
++        cg_hierarchy_base = b;
++
++        return 0;
++}
+diff --git a/src/shared/cgroup-util.h b/src/shared/cgroup-util.h
+index b6f28c5..07e6d7e 100644
+--- a/src/shared/cgroup-util.h
++++ b/src/shared/cgroup-util.h
+@@ -163,3 +163,5 @@ int cg_kernel_controllers(Set *controllers);
+ 
+ int cg_cpu_shares_parse(const char *s, uint64_t *ret);
+ int cg_blkio_weight_parse(const char *s, uint64_t *ret);
++
++int cg_set_hierarchy_base(const char *path);
+-- 
+2.36.1
+


### PR DESCRIPTION
**Issue number:** #75 


**Description of changes:** This PR aims to make the admin container work on Bottlerocket hosts with cgroup v2/the unified cgroup hierarchy enabled (rather than the current cgroup v1 default). The current version of the admin container is hindered by systemd v219 inside its image not supporting cgroup v2, and no more recent version of systemd being available for the Amazon Linux 2 base image.

The PR introduces a dedicated but unused cgroup v1 hierarchy just for the admin container. It instructs the user systemd process inside the container to use this separate hierarchy via downstream patches. In order to apply those systemd needs to be recompiled during the build process.

The core of this goes back to @bcressey noting the cgroup v1 filesystem can be mounted without any controllers. I take responsibility for actually running with this and deciding to patch systemd inside the container. The benefit of this compared to doing it on the host is that all code required for the admin container actually stays inside the admin container, and no changes at all can be observed on hosts that are not running the admin container.

**Testing done:** Locally with cgroup v1 and cgroup v2 VMs.

To test with cgroup v2 enabled, add the following user data snippet on boot

```
[settings.boot]
reboot-to-reconcile = true

[settings.boot.init]
"systemd.unified_cgroup_hierarchy" = ["1"]
```

or apply the corresponding settings at runtime using `apiclient set -j '{"settings": {"boot": {"init": {"systemd.unified_cgroup_hierarchy": ["1"]}}}}'` and reboot.

The container image with the changes from this PR can be used both on a cgroup v1 and a cgroup v2 host. Host access using `sudo sheltie` works just the same. The admin container can be stopped/disabled and restarted/reenabled.

I launched a few pods into a Kubernetes cluster with a node that used the cgroup v2 hierarchy. I then verified on the host that the containers were running in the cgroup v2 hierarchy.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
