### PR TITLE
Fix systemd warning about conflicting jobs when the admin container exits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,8 @@ RUN last_patch=$(awk '/^Patch[0-9]+/ { line = NR } END { print line }' systemd.s
     { \
         echo ;\
         echo '# Bottlerocket Patches'; \
-        echo 'Patch9501: 9500-cgroup-util-extract-cgroup-hierarchy-base-path-into-.patch'; \
-        echo 'Patch9502: 9501-cgroup-util-accept-cgroup-hierarchy-base-as-option.patch'; \
+        echo 'Patch9500: 9500-cgroup-util-extract-cgroup-hierarchy-base-path-into-.patch'; \
+        echo 'Patch9501: 9501-cgroup-util-accept-cgroup-hierarchy-base-as-option.patch'; \
         echo ; \
     } >>systemd.mod.spec; \
     tail -n+$((last_patch + 1)) systemd.spec >>systemd.mod.spec; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,8 @@ RUN last_patch=$(awk '/^Patch[0-9]+/ { line = NR } END { print line }' systemd.s
         echo '# Bottlerocket Patches'; \
         echo 'Patch9500: 9500-cgroup-util-extract-cgroup-hierarchy-base-path-into-.patch'; \
         echo 'Patch9501: 9501-cgroup-util-accept-cgroup-hierarchy-base-as-option.patch'; \
+        echo 'Patch9502: 9502-core-move-initialization-of-.slice-and-init.scope-in.patch'; \
+        echo 'Patch9503: 9503-core-drop-.slice-from-shipped-units.patch'; \
         echo ; \
     } >>systemd.mod.spec; \
     tail -n+$((last_patch + 1)) systemd.spec >>systemd.mod.spec; \

--- a/systemd-patches/9502-core-move-initialization-of-.slice-and-init.scope-in.patch
+++ b/systemd-patches/9502-core-move-initialization-of-.slice-and-init.scope-in.patch
@@ -1,0 +1,75 @@
+From 0b9c1623c2d51b0e1e51ec9cdbb89eee03118102 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 24 Oct 2016 20:37:54 +0200
+Subject: [PATCH] core: move initialization of -.slice and init.scope into the
+ unit_load() callbacks
+
+Previously, we'd synthesize the root slice unit and the init scope unit in the
+enumerator callbacks for the unit type. This is problematic if either of them
+is already referenced from a unit that is loaded as result of another unit
+type's enumerator logic.
+
+Let's clean this up and simply create the two objects from the enumerator
+callbacks, if they are not around yet. Do the actual filling in of the settings
+from the unit_load() callbacks, to match how other units are loaded.
+
+Fixes: #4322
+
+(cherry picked from commit 8e4e851f1ddc98daf69b68998afc5a096ea17893)
+
+Only retain the logic to synthesize the root slice unit. The init scope
+does not exist yet in v219 and only was introduced with the work to
+support the unified cgroup hierarchy in v226.
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ src/core/slice.c | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/src/core/slice.c b/src/core/slice.c
+index b0769205f6..f533efdd97 100644
+--- a/src/core/slice.c
++++ b/src/core/slice.c
+@@ -129,12 +129,39 @@ static int slice_verify(Slice *s) {
+         return 0;
+ }
+ 
++static int slice_load_root_slice(Unit *u) {
++        assert(u);
++
++        if (!unit_has_name(u, SPECIAL_ROOT_SLICE))
++                return 0;
++
++        u->no_gc = true;
++
++        /* The root slice is a bit special. For example it is always running and cannot be terminated. Because of its
++         * special semantics we synthesize it here, instead of relying on the unit file on disk. */
++
++        u->default_dependencies = false;
++        u->ignore_on_isolate = true;
++        u->refuse_manual_start = true;
++        u->refuse_manual_stop = true;
++
++        if (!u->description)
++                u->description = strdup("Root Slice");
++        if (!u->documentation)
++                u->documentation = strv_new("man:systemd.special(7)", NULL);
++
++        return 1;
++}
++
+ static int slice_load(Unit *u) {
+         Slice *s = SLICE(u);
+         int r;
+ 
+         assert(s);
+ 
++        r = slice_load_root_slice(u);
++        if (r < 0)
++                return r;
+         r = unit_load_fragment_and_dropin_optional(u);
+         if (r < 0)
+                 return r;
+-- 
+2.39.1
+

--- a/systemd-patches/9503-core-drop-.slice-from-shipped-units.patch
+++ b/systemd-patches/9503-core-drop-.slice-from-shipped-units.patch
@@ -1,0 +1,71 @@
+From cc601c173d6bdeaf6fcc2de476db4ee7ef99607a Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 24 Oct 2016 20:49:48 +0200
+Subject: [PATCH] core: drop -.slice from shipped units
+
+Since this unit is synthesized anyway there's no point in actually shipping it
+on disk. This also has the benefit that "cd /usr/lib/systemd/system ; ls *"
+won't be confused by the leading dash of the file name anymore.
+
+(cherry picked from commit 828d92acbc8e6f536419cfaee10d6b5c7b0d7f82)
+
+Fixed up context to apply to v219.
+
+Signed-off-by: Markus Boehme <markubo@amazon.com>
+---
+ Makefile.am    | 12 ------------
+ units/x-.slice | 12 ------------
+ 2 files changed, 24 deletions(-)
+ delete mode 100644 units/x-.slice
+
+diff --git a/Makefile.am b/Makefile.am
+index 648f54b957..13ac6fbb0c 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -494,7 +494,6 @@ dist_systemunit_DATA = \
+ 	units/swap.target \
+ 	units/slices.target \
+ 	units/system.slice \
+-	units/x-.slice \
+ 	units/systemd-initctl.socket \
+ 	units/systemd-shutdownd.socket \
+ 	units/syslog.socket \
+@@ -629,17 +628,6 @@ EXTRA_DIST += \
+ 	units/rc-local.service.in \
+ 	units/halt-local.service.in
+ 
+-# automake is broken and can't handle files with a dash in front
+-# http://debbugs.gnu.org/cgi/bugreport.cgi?bug=14728#8
+-units-install-hook:
+-	mv $(DESTDIR)$(systemunitdir)/x-.slice $(DESTDIR)/$(systemunitdir)/-.slice
+-
+-units-uninstall-hook:
+-	rm -f $(DESTDIR)/$(systemunitdir)/-.slice
+-
+-INSTALL_DATA_HOOKS += units-install-hook
+-UNINSTALL_DATA_HOOKS += units-uninstall-hook
+-
+ dist_doc_DATA = \
+ 	README \
+ 	NEWS \
+diff --git a/units/x-.slice b/units/x-.slice
+deleted file mode 100644
+index ac82c35874..0000000000
+--- a/units/x-.slice
++++ /dev/null
+@@ -1,12 +0,0 @@
+-#  This file is part of systemd.
+-#
+-#  systemd is free software; you can redistribute it and/or modify it
+-#  under the terms of the GNU Lesser General Public License as published by
+-#  the Free Software Foundation; either version 2.1 of the License, or
+-#  (at your option) any later version.
+-
+-[Unit]
+-Description=Root Slice
+-Documentation=man:systemd.special(7)
+-DefaultDependencies=no
+-Before=slices.target
+-- 
+2.39.1
+


### PR DESCRIPTION
**Issue number:** Closes #62 

**Description of changes:** When exiting the admin container, the user instance of systemd logs the following and skips proper clean-up:

    Requested transaction contains unmergeable jobs: Transaction contains conflicting jobs 'stop' and 'start' for systemd-exit.service. Probably contradicting requirement dependencies configured.
    Failed to enqueue exit.target job: Transaction contains conflicting jobs 'stop' and 'start' for systemd-exit.service. Probably contradicting requirement dependencies configured.

Exiting a user instance of systemd starts the `exit.target`, which depends on `systemd-exit.service`, which in turn depends on `-.slice` (the root slice) and `shutdown.target`. The stated conflict is between the latter two, with `-.slice` defining a conflict with `shutdown.target`.

Resolve the conflict by backporting a change from upstream systemd that only synthesizes the root slice. This ensures systemd in the container exits properly, and e.g. removes empty cgroups.

**Reviewer notes:** The upstream change is https://github.com/systemd/systemd/pull/4477

**Testing done:**
1. Built an image with the changes and ran it on the metal-dev variant on an aarch64 EC2 instance.
2. The admin container launches properly and is accessible via SSH.
3. When I run `apiclient set settings.host-containers.admin.enabled=false`, the admin container stops running.
4. When I check the journal on the host via `journalctl -u host-containers@admin.service`, the container
4.1. exited cleanly with a zero exit status
4.2. without any warnings or errors.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
