### PR TITLE
Stop unnecessary reverse lookup of incoming SSH connections

### DIFF
--- a/sshd_config
+++ b/sshd_config
@@ -19,3 +19,5 @@ PermitRootLogin no
 
 # Configured by user data
 TrustedUserCAKeys /etc/ssh/trusted_user_ca_keys.pub
+
+UseDNS no


### PR DESCRIPTION


<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #84 


**Description of changes:** Disable reverse lookup of hostnames for incoming SSH connections. Neither the sshd configuration nor the authorized_keys file generated at the start of the admin container make use of the hostname information, so save the unnecessary requests.


**Testing done:** Can still connect to the admin container both via explicit key pair and via EC2 Instance Connect on both cgroup v1 (aws-k8s-1.23) and cgroup v2 (aws-k8s-1.27) hosts. Observing `tcpdump 'port 53'` from within the admin container shows no more DNS requests on incoming SSH connections.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
