### PR TITLE
Allow setting MACs in SSHD config

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,31 @@ To change allowed key exchange algorithms to a specific set, you can add a
 }
 ```
 
+To change allowed MACs to a specific set, you can add a `macs` section:
+
+```json
+{
+  "ssh": {
+    "authorized-keys...",
+    "macs": [
+      "hmac-sha2-256",
+      "hmac-sha2-512",
+      "umac-64@openssh.com",
+      "umac-128@openssh.com",
+      "hmac-sha2-256-etm@openssh.com",
+      "hmac-sha2-512-etm@openssh.com",
+      "hmac-md5-etm@openssh.com",
+      "hmac-md5-96-etm@openssh.com",
+      "umac-64-etm@openssh.com",
+      "umac-128-etm@openssh.com"
+    ]
+  }
+}
+```
+
+You can also tweak ciphers, key exchange algorithms and MACs following way (see https://man.openbsd.org/sshd_config for details):
+- If the specified list begins with a ‘+’ character, then the specified entries will be appended to the default set instead of replacing them. If the specified list begins with a ‘-’ character, then the specified entries (including wildcards) will be removed from the default set instead of replacing them. If the specified list begins with a ‘^’ character, then the specified entries will be placed at the head of the default set.
+
 By default, the admin container's local user will be `ec2-user`. If you would like to change this, you can set the user value like so:
 
 ```json

--- a/start_admin.sh
+++ b/start_admin.sh
@@ -170,6 +170,11 @@ if kex_algorithms=$(jq -r -e -c '.["ssh"]["key-exchange-algorithms"]? | join(","
   echo "KexAlgorithms ${kex_algorithms}" >> "${SSHD_CONFIG_FILE}"
 fi
 
+# Populate MACs with all the MACs found in user-data
+if macs=$(jq -r -e -c '.["ssh"]["macs"]? | join(",")' "${USER_DATA}" 2>/dev/null); then
+  echo "MACs ${macs}" >> "${SSHD_CONFIG_FILE}"
+fi
+
 # Check the configurations are for EC2 Instance Connect
 declare -i use_eic=0
 if [[ $authorized_keys_command == /opt/aws/bin/eic_run_authorized_keys* ]] \


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

https://github.com/bottlerocket-os/bottlerocket-admin-container/issues/90

**Description of changes:**

This change adds option to customize MACs for SSH , for example, to disable SHA1 MACs which are reported as deprecated by vulnerability scanner. README.md updated.

**Testing done:**

Created custom container and tested in my lab cluster, works as expected.

SSHD config contains line:
`MACs hmac-sha2-256,hmac-sha2-512,hmac-md5,hmac-md5-96,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,umac-64-etm@openssh.com,umac-128-etm@openssh.com`

SSHD server offers just MACs selected by me:
```
debug2: MACs ctos: hmac-sha2-256,hmac-sha2-512,hmac-md5,hmac-md5-96,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,umac-64-etm@openssh.com,umac-128-etm@openssh.com
debug2: MACs stoc: hmac-sha2-256,hmac-sha2-512,hmac-md5,hmac-md5-96,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,umac-64-etm@openssh.com,umac-128-etm@openssh.com
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
