### PR TITLE
Allow setting port in SSHD config

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ To change allowed MACs to a specific set, you can add a `macs` section:
 }
 ```
 
+To change the port that the admin container SSH daemon is running on (default is 22), you can add a `port` section:
+
+```json
+{
+  "ssh": {
+    "authorized-keys...",
+    "port": 1234
+  }
+}
+```
+
 You can also tweak ciphers, key exchange algorithms and MACs following way (see https://man.openbsd.org/sshd_config for details):
 - If the specified list begins with a ‘+’ character, then the specified entries will be appended to the default set instead of replacing them. If the specified list begins with a ‘-’ character, then the specified entries (including wildcards) will be removed from the default set instead of replacing them. If the specified list begins with a ‘^’ character, then the specified entries will be placed at the head of the default set.
 

--- a/start_admin.sh
+++ b/start_admin.sh
@@ -185,6 +185,11 @@ if macs=$(jq -r -e -c '.["ssh"]["macs"]? | join(",")' "${USER_DATA}" 2>/dev/null
   echo "MACs ${macs}" >> "${SSHD_CONFIG_FILE}"
 fi
 
+# Set custom SSH port if specified in user-data
+if ssh_port=$(jq -r -e '.["ssh"]["port"]?' "${USER_DATA}" 2>/dev/null); then
+  echo "Port ${ssh_port}" >> "${SSHD_CONFIG_FILE}"
+fi
+
 # Check the configurations are for EC2 Instance Connect
 declare -i use_eic=0
 if [[ $authorized_keys_command == /opt/aws/bin/eic_run_authorized_keys* ]] \


### PR DESCRIPTION
**Issue number:**

#112

**Description of changes:**

Add support for customizing the SSH daemon port in the admin container. README.md updated.

**Testing done:**
Built and deployed a custom admin container with the port customization feature.
Verified functionality by configuring a non-standard port (1234) in user-data, then confirmed the SSH daemon was correctly listening on the specified port using `ss -tlnp | grep sshd`
Admin container connected and works as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
