### PR TITLE
ssh-keygen: fix command when generating hostkeys

### DIFF
--- a/start_admin.sh
+++ b/start_admin.sh
@@ -239,8 +239,7 @@ for key_alg in "${key_algorithms[@]}"; do
     "${SSH_HOST_KEY_DIR}/ssh_host_${key_alg}_key" \
     "${SSH_HOST_KEY_DIR}/ssh_host_${key_alg}_key.pub"
 
-  if ssh-keygen -t "${key_alg}" -f 
-"${SSH_HOST_KEY_DIR}/ssh_host_${key_alg}_key" -q -N ""; then
+  if ssh-keygen -t "${key_alg}" -f "${SSH_HOST_KEY_DIR}/ssh_host_${key_alg}_key" -q -N ""; then
 
     chmod 600 "${SSH_HOST_KEY_DIR}/ssh_host_${key_alg}_key"
     chmod 644 "${SSH_HOST_KEY_DIR}/ssh_host_${key_alg}_key.pub"


### PR DESCRIPTION
**Description of changes:**
* Removed linebreak in ssh-keygen command.  This resulted in a malformed command and we were unable to generate hostkeys.

**Testing done:**
* Ran build
* Tested SSH connection into instance

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
