### PR TITLE
fix: replace dnf update with dnf upgrade --releasever=latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 # Base image for all builds
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS builder-base
-RUN dnf group install -y "Development Tools"
+RUN dnf upgrade -y --releasever=latest && \
+  dnf group install -y "Development Tools"
 RUN useradd builder
 
 
@@ -10,7 +11,8 @@ RUN useradd builder
 # Statically linked, more recent version of bash
 
 FROM builder-base AS builder-static
-RUN dnf install -y glibc-static
+RUN dnf upgrade -y --releasever=latest && \
+  dnf install -y glibc-static
 
 ARG musl_version=1.2.5
 ARG bash_version=5.2.37
@@ -68,7 +70,7 @@ ARG IMAGE_VERSION
 RUN test -n "$IMAGE_VERSION"
 LABEL "org.opencontainers.image.version"="$IMAGE_VERSION"
 
-RUN dnf update -y \
+RUN dnf upgrade -y --releasever=latest \
     && dnf install -y \
         crypto-policies-scripts \
         ec2-instance-connect \


### PR DESCRIPTION
**Description of changes:**

AL2023 base container images are pinned to a specific release version for reproducibility. A plain `dnf upgrade` will only pull packages from that pinned release, which defeats the purpose of updating to the latest available patches.

`--releasever=latest` overrides the version lock and tells `dnf` to fetch from the latest AL2023 release repositories, which is the equivalent behavior to what `yum update` gave us on AL2.

**Testing done:**

`make`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
